### PR TITLE
About Page backend changes

### DIFF
--- a/src/api/content-about-collaborator/content-types/content-about-collaborator/schema.json
+++ b/src/api/content-about-collaborator/content-types/content-about-collaborator/schema.json
@@ -24,8 +24,7 @@
         "DevUXInterns",
         "InauguralTeam",
         "SteeringCommittee",
-        "InternalAdvisoryCommittee",
-        "ExternalAdvisoryCommittee",
+        "InauguralAdvisoryCommittees",
         "DonorGrantingAgencies",
         "EditorialBoardFellows",
         "EditorialBoardLeads"

--- a/src/api/content-about/content-types/content-about/schema.json
+++ b/src/api/content-about/content-types/content-about/schema.json
@@ -137,6 +137,12 @@
         "audios"
       ],
       "multiple": false
+    },
+    "BehindTheScenes_Video1": {
+      "type": "string"
+    },
+    "BehindTheScenes_Video2": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
- Added two fields for Youtube video reels on About Page
- Renamed InternalAdvisoryCommittee to InauguralAdvisoryCommittees
- Removed ExternalAdvisoryCommittee